### PR TITLE
Make cfg path macro: EPICS_IOCSH_CFG_PATH

### DIFF
--- a/iocsh
+++ b/iocsh
@@ -85,10 +85,17 @@ then
     fi
 fi
 
-if read BASE < EPICSVERSION || read BASE < cfg/EPICSVERSION
-then
-    unset EPICS_BASE
-fi 2> /dev/null
+export EPICS_IOCSH_CFG_PATH=./:cfg/:/etc/:$EPICS_IOCSH_CFG_PATH
+
+for dir in $(echo "$EPICS_IOCSH_CFG_PATH" | tr ':' ' ')
+do
+    if read BASE < $dir/EPICSVERSION
+    then
+        unset EPICS_BASE
+        break
+    fi 2> /dev/null
+done
+
 
 # IOC name derives from hostname
 # (trailing possible '\r' under cygwin)
@@ -334,7 +341,7 @@ PATH=$PATH:$INSTBASE/iocBoot/R$BASE/$EPICS_HOST_ARCH:$EPICS_BASE/bin/$EPICS_HOST
 export EPICS_IOCSH_HISTFILE=
 
 # Call init script after IOC name, EPICS_HOST_ARCH and EPICS_BASE are set.
-for dir in . cfg /etc
+for dir in $(echo "$EPICS_IOCSH_CFG_PATH" | tr ':' ' ')
 do
     if [ -r "$dir/iocsh.init" ]
     then


### PR DESCRIPTION
It was needed to read mainly iocsh.init from other path then the options contained at iocsh script.
I created a macro `EPICS_IOCSH_CFG_PATH `for that to be configured. Took the chance also to include `EPICSVERSION `also in the same path.
The previous defined paths takes precedence in the same order: `./`, `cfg/` and `/etc/`.